### PR TITLE
Add eBay script to skip over extra-charge fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ having to click the pagination links.
 
   Reset fields more typical of plain month-long fixed-priced items.
 
+- [Skip extra-charge fields](./ebay-skip-unused-fields.user.js)
+
+  Lock out options not necessarily used like Subtitle, Gallery
+
 ### Misc
 
 - [Projector Redirect back into timesheet](./projector-timesheet-redirect.user.js)

--- a/ebay-skip-unused-fields.user.js
+++ b/ebay-skip-unused-fields.user.js
@@ -1,0 +1,25 @@
+// ==UserScript==
+// @name         eBay - Skip extra-charge, unused options
+// @namespace    randomecho.com
+// @version      0.1
+// @description  Lock out options not necessarily used like Subtitle, Gallery
+// @author       Soon Van - randomecho.com
+// @match        https://bulksell.ebay.com/ws/eBayISAPI.dll?SingleList*
+// @license      http://opensource.org/licenses/BSD-3-Clause
+// @grant        none
+// ==/UserScript==
+
+function lockoutField(fieldName) {
+  let fielded = document.getElementById(fieldName);
+
+  if (fielded) {
+    fielded.value = '';
+    fielded.readOnly = true;
+    fielded.disabled = true;
+  }
+}
+
+lockoutField('bold');
+lockoutField('editpane_subtitle');
+lockoutField('galleryPlus');
+lockoutField('Listing.AutoRelist');


### PR DESCRIPTION
Extra-charge fields being those that are premium to the normal
listing, such as:

- Subtitle
- Large Photo in gallery

Another in the way is the auto relist, which might catch you
off-guard if you want to evaluate between runs and not necessarily
just hoist it back up.